### PR TITLE
Display request headers & improvements

### DIFF
--- a/Command/GenerateCommand.php
+++ b/Command/GenerateCommand.php
@@ -53,7 +53,7 @@ class GenerateCommand extends \Symfony\Component\Console\Command\Command {
                     if (is_object($request->request->url)){
                         $request->request->url = $request->request->url->raw;
                     }
-                    $pageFilename = str_ireplace(array('/','\\','.',' ','?'),'_', $request->name) . ".html";
+                    $pageFilename = strtolower($request->request->method) . '_' . str_ireplace(array('/','\\','.',' ','?'),'_', $request->name) . ".html";
                     $request->page_path = 'requests/' . $pageFilename;
                     if (!property_exists($request, 'response') ||  !count($request->response)) {
                         $output->writeln("Warning: {$request->name} has no response examples");

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,8 @@
 {% include 'header.html' %}
 <div class="container-fluid">
     <div class="row">
-        {{ include('sidebar.html', {current_folder: request.folder, current_request: request.name} ) }}
+        {% set current_request = request.request.method ~ '_' ~ request.name %}
+        {{ include('sidebar.html', {current_folder: request.folder, current_request: current_request} ) }}
         <div class="col-sm-8 col-sm-offset-4 col-md-9 col-md-offset-3 main">
             <h1> {{meta.projectName}} API Documentation </h1>
 

--- a/templates/request.html
+++ b/templates/request.html
@@ -12,7 +12,8 @@
 {{ include('header.html',{urlsuffix:'../'}) }}
 <div class="container-fluid">
     <div class="row">
-        {{ include('sidebar.html', {current_folder: request.folder, current_request: request.name, urlsuffix:'../'} ) }}
+        {% set current_request = request.request.method ~ '_' ~ request.name %}
+        {{ include('sidebar.html', {current_folder: request.folder, current_request: current_request, urlsuffix:'../'} ) }}
         <div class="col-sm-8 col-sm-offset-4 col-md-9 col-md-offset-3 main">
             <h1> {{request.name}} </h1>
 

--- a/templates/request.html
+++ b/templates/request.html
@@ -30,6 +30,23 @@
                 </div>
             </div>
 
+            {% if request.request.header is not empty  %}
+            <div class="panel panel-primary">
+                <div class="panel-heading">Header</div>
+                <div class="panel-body">
+                    <table class="table table-hover ">
+                        <tbody>
+                        {% for header in request.request.header %}
+                        {% if header.disabled != true %}
+                        <tr><th>{{header.key}}</th><td>{{header.value}}</td></tr>
+                        {% endif %}
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            {% endif %}
+
             {% if request.request.method != 'GET' %}
             {% if request.request.body.mode == 'formdata' %}
             <div class="panel panel-primary">
@@ -60,23 +77,6 @@
                 </div>
             </div>
             {% endif %}
-            {% endif %}
-
-            {% if request.request.header is not empty  %}
-            <div class="panel panel-primary">
-                <div class="panel-heading">Header</div>
-                <div class="panel-body">
-                    <table class="table table-hover ">
-                        <tbody>
-                        {% for header in request.request.header %}
-                        {% if header.disabled != true %}
-                        <tr><th>{{header.key}}</th><td>{{header.value}}</td></tr>
-                        {% endif %}
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
             {% endif %}
 
             {% if request.response | length >0 %}

--- a/templates/request.html
+++ b/templates/request.html
@@ -17,7 +17,7 @@
             <h1> {{request.name}} </h1>
 
             <div class="panel panel-primary">
-            <div class="panel-heading">Request Information</div>  
+                <div class="panel-heading">Request Information</div>
                 <div class="panel-body">
                     <table class="table table-hover ">
                       <tbody>
@@ -59,6 +59,23 @@
                 </div>
             </div>
             {% endif %}
+            {% endif %}
+
+            {% if request.request.header is not empty  %}
+            <div class="panel panel-primary">
+                <div class="panel-heading">Header</div>
+                <div class="panel-body">
+                    <table class="table table-hover ">
+                        <tbody>
+                        {% for header in request.request.header %}
+                        {% if header.disabled != true %}
+                        <tr><th>{{header.key}}</th><td>{{header.value}}</td></tr>
+                        {% endif %}
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
             {% endif %}
 
             {% if request.response | length >0 %}

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -2,12 +2,29 @@
 	<div class="panel-group" role="tablist">
 		<div class="panel panel-default">
 		{% for folder in folders %}
+			{% set collapsed = true %}
+
+			{% for request in folder.requests %}
+				{% set current = request.request.method ~ '_' ~ request.name %}
+				{% if current == current_request %}
+					{% set collapsed = false %}
+				{% endif %}
+			{% endfor %}
+
+
 			<div class="panel-heading" role="tab" id="collapseListGroupHeading{{loop.index}}">
-				<h4 class="panel-title"> <a href="#collapseListGroup{{loop.index}}" class="collapsed" role="button" data-toggle="collapse" aria-expanded="" aria-controls="collapseListGroup{{loop.index}}">{{ folder.name }}</a> </h4>
+				<h4 class="panel-title"> <a href="#collapseListGroup{{loop.index}}" class="{{ collapsed ? 'collapsed' : ''}}" role="button" data-toggle="collapse" aria-expanded="{{ collapsed ? 'false' : 'true' }}" aria-controls="collapseListGroup{{loop.index}}">{{ folder.name }}</a> </h4>
 			</div>
-			<div class="panel-collapse collapse " role="tabpanel" id="collapseListGroup{{loop.index}}" aria-labelledby="collapseListGroupHeading{{loop.index}}" aria-expanded="" style="height: 0px;"> 
+			<div class="panel-collapse collapse {{ collapsed ? '' : 'in' }}" role="tabpanel" id="collapseListGroup{{loop.index}}" aria-labelledby="collapseListGroupHeading{{loop.index}}" aria-expanded="{{ collapsed ? 'false' : 'true' }}" style="{{ collapsed ? 'height: 0px;' : '' }}">
 				<ul class="list-group">
-					{% for request in folder.requests %}<li class="list-group-item {{ request.name == current_request? 'active':''}}"><a href="{{urlsuffix}}{{ request.page_path }}">{{ request.name }}</a></li>{% endfor %}
+					{{folderClass}}
+
+					{% for request in folder.requests %}
+					{% set current = request.request.method ~ '_' ~ request.name %}
+					<li style="word-wrap: break-word;" class="list-group-item {{ current == current_request ? 'active' : ''}}">
+						<a href="{{urlsuffix}}{{ request.page_path }}">{{ request.request.method }} - {{ request.name }}</a>
+					</li>
+					{% endfor %}
 				</ul> 
 			</div>
 		{% endfor %}


### PR DESCRIPTION
Hello,

Here is the previously mentioned PR including the following changes:
- Request headers are now displayed under the request information
- Add sidebar state preservation (folder is expanded if containing the current request)
- Prefix page name with the request method allowing multiple page with the same name but different methods (RESTFul)

The sidebar state preservation seems messy, sorry about that, if you find a nicer way do not hesitate !

Best Regards,
Kevin