### PR TITLE
Dockerfile: support docker build docodile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:7.1-jessie
+
+RUN ln -sf /bin/bash /bin/sh && apt-get update && apt-get install -y git python3 unzip locales --no-install-recommends \
+    && printf "zh_CN.UTF-8 UTF-8\nen_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+    && curl -sS -C - -L https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+
+# ENV LANG zh_CN.UTF-8
+
+RUN git clone https://github.com/JakeWorrell/docodile.git /usr/local/src/docodile && pushd /usr/local/src/docodile && composer install
+
+WORKDIR /usr/local/src/docodile


### PR DESCRIPTION
To avoid waste of time to build docodile tools, so support docker. Related operaion should be simple:  
```
$ docker build --tag postman-docodile --network host --file ./Dockerfile .       
                                                                                                                        
$ docker run -ti -v $(pwd):/data postman-docodile:latest /bin/bash
    $$ docodile generate -blumen -jgruvbox-light /data/postman.json --force /target 
    $$ cd target 
    $$ python3 -m http.server 
```
About ENV variable, I add comment to support common language, English.  

If someone postman-collections have Chinese, you can:  
 * uncomment `ENV` instruction and then docker build
 * `export LANG=zh_CN.UTF-8` and then start http server